### PR TITLE
fix: XYTree: add-struct-tree

### DIFF
--- a/include/data/XYTree.h
+++ b/include/data/XYTree.h
@@ -12,9 +12,9 @@ using namespace std;
 namespace XYTree {
     struct Node {
         int index;
-        int r = 0;
-        shared_ptr<Node> next = nullptr;    // TODO: Y-tree에서는 필요 없는 값. 최적화 시 Y-tree에선 삭제 가능.
-        Interval children = Interval(0, 0); // [start, end]
+        int r;
+        shared_ptr<Node> next;  // TODO: Y-tree에서는 필요 없는 값. 최적화 시 Y-tree에선 삭제 가능.
+        Interval children;      // [start, end]
     
         Node(int index);
     };

--- a/include/data/XYTree.h
+++ b/include/data/XYTree.h
@@ -14,7 +14,7 @@ namespace XYTree {
         int index;
         int r = 0;
         shared_ptr<Node> next = nullptr;    // TODO: Y-tree에서는 필요 없는 값. 최적화 시 Y-tree에선 삭제 가능.
-        Interval children = Interval(0, 0); // [start, end)
+        Interval children = Interval(0, 0); // [start, end]
     
         Node(int index);
     };

--- a/include/data/XYTree.h
+++ b/include/data/XYTree.h
@@ -3,16 +3,18 @@
 
 #include <string>
 #include <memory>
-#include "Ranker.h"
-#include "Shortlex.h"
+#include "data/Ranker.h"
+#include "data/Shortlex.h"
+#include "utils/Common.h"
 
 using namespace std;
 
 namespace XYTree {
     struct Node {
         int index;
-        int r;
+        int r = 0;
         shared_ptr<Node> next = nullptr;    // TODO: Y-tree에서는 필요 없는 값. 최적화 시 Y-tree에선 삭제 가능.
+        Interval children = Interval(0, 0); // [start, end)
     
         Node(int index);
     };
@@ -21,7 +23,6 @@ namespace XYTree {
         shared_ptr<Node> root;
 
         vector<shared_ptr<Node>> parent;    // TODO: X-tree에서는 필요 없는 값. 최적화 시 X-tree에선 삭제 가능.
-        vector<vector<int>> children;       // 논문에서는 interval이긴 한데, 일단 vector로 처리함
     };
 
     // Build X-tree using the X-ranker, ShortlexResult, and input text

--- a/include/data/XYTree.h
+++ b/include/data/XYTree.h
@@ -12,17 +12,22 @@ namespace XYTree {
     struct Node {
         int index;
         int r;
-        shared_ptr<Node> parent = nullptr;
-        vector<shared_ptr<Node>> children;
-        shared_ptr<Node> next = nullptr;
+        shared_ptr<Node> next = nullptr;    // TODO: Y-tree에서는 필요 없는 값. 최적화 시 Y-tree에선 삭제 가능.
     
         Node(int index);
     };
 
+    struct Tree {
+        shared_ptr<Node> root;
+
+        vector<shared_ptr<Node>> parent;    // TODO: X-tree에서는 필요 없는 값. 최적화 시 X-tree에선 삭제 가능.
+        vector<vector<int>> children;       // 논문에서는 interval이긴 한데, 일단 vector로 처리함
+    };
+
     // Build X-tree using the X-ranker, ShortlexResult, and input text
-    shared_ptr<Node> buildXTree(const RankerTable& ranker, const ShortlexResult& shortlex, const string& text);
+    Tree buildXTree(const RankerTable& ranker, const ShortlexResult& shortlex, const string& text);
 
     // Build Y-tree using the Y-ranker, ShortlexResult, and input text
-    shared_ptr<Node> buildYTree(const RankerTable& ranker, const ShortlexResult& shortlex, const string& text);
+    Tree buildYTree(const RankerTable& ranker, const ShortlexResult& shortlex, const string& text);
 }
 #endif // XYTREE_H

--- a/include/utils/Common.h
+++ b/include/utils/Common.h
@@ -3,6 +3,13 @@
 
 #include <limits>
 
+struct Interval {
+  int start;
+  int end;
+
+  Interval(int start, int end) : start(start), end(end) {};
+};
+
 constexpr int INF = std::numeric_limits<int>::max();
 
-#endif // COMMON_H
+#endif  // COMMON_H

--- a/include/utils/Common.h
+++ b/include/utils/Common.h
@@ -7,6 +7,7 @@ struct Interval {
   int start;
   int end;
 
+  Interval() {};
   Interval(int start, int end) : start(start), end(end) {};
 };
 

--- a/src/data/XYTree.cpp
+++ b/src/data/XYTree.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 using namespace XYTree;
 
-Node::Node(int index) : index(index) {}
+Node::Node(int index) : index(index) {};
 
 /**
  * @brief X-Tree Construction given precomputed components.
@@ -22,7 +22,6 @@ XYTree::Tree XYTree::buildXTree(const RankerTable& ranker, const ShortlexResult&
     shared_ptr<Node> root = make_shared<Node>(INF);
     tree.root = root;
     tree.parent = vector<shared_ptr<Node>>(text.size() + 1);
-    tree.children = vector<vector<int>>(text.size() + 1);
 
     unordered_map<int, shared_ptr<Node>> nodes;
     nodes[INF] = root;
@@ -106,16 +105,13 @@ XYTree::Tree XYTree::buildXTree(const RankerTable& ranker, const ShortlexResult&
                     sp_p.pop_back();
                 }
             }
+
+            // line 18: T_X(T).chld(parent) <- [i, i)
+            parent_node->children = Interval(i, i);
         }
         
-        // line 18: T_X(T).chld(parent) <- [i, i)
         // line 19: extend end point of T_X(`T`).chld(parent) by one
-        if (parent != INF) {
-            tree.children[parent].push_back(i);
-        }
-        else {
-            tree.children.back().push_back(i);
-        }
+        nodes[parent]->children.end++;
 
         // line 21: T_X(T).prnt(i) <- parent (Note: 논문의 Algorithm 1 에서는 i가 Nodes에 포함인 경우에만 하도록 되어있지만, 6페이지에 모든 i에 대하여 prnt(i)가 작동하도록 하게끔 abuse한다는 내용이 있음)
         tree.parent[i] = nodes[parent];
@@ -144,7 +140,6 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
     shared_ptr<Node> root = make_shared<Node>(-1);
     tree.root = root;
     tree.parent = vector<shared_ptr<Node>>(text.size() + 1);
-    tree.children = vector<vector<int>>(text.size() + 1);
 
     unordered_map<int, shared_ptr<Node>> nodes;
     nodes[-1] = root;
@@ -229,16 +224,13 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
                     sp_p.pop_back();
                 }
             }
+
+            // line 18: T_Y(T).chld(parent) <- [i, i)
+            parent_node->children = Interval(i, i);
         }
 
-        // line 18: T_Y(T).chld(parent) <- [i, i)
         // line 19: extend end point of T_Y(T).chld(parent) by one
-        if (parent != -1) {
-            tree.children[parent].push_back(i);
-        }
-        else {
-            tree.children.back().push_back(i);
-        }
+        nodes[parent]->children.start--;
 
         // line 21: T_Y(T).prnt(i) <- parent (Note: 논문의 Algorithm 1 에서는 i가 Nodes에 포함인 경우에만 하도록 되어있지만, 6페이지에 모든 i에 대하여 prnt(i)가 작동하도록 하게끔 abuse한다는 내용이 있음)
         tree.parent[i] = nodes[parent];

--- a/src/data/XYTree.cpp
+++ b/src/data/XYTree.cpp
@@ -226,7 +226,7 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
             }
 
             // line 18: T_Y(T).chld(parent) <- [i, i]   // 논문에서는 [i, i)지만 편의상 [i, i]를 쓰기로
-            parent_node->children = Interval(i, i - 1); // line 19 에서 [i, i]로 바뀔 것
+            parent_node->children = Interval(i + 1, i); // line 19 에서 [i, i]로 바뀔 것
         }
 
         // line 19: extend end point of T_Y(T).chld(parent) by one

--- a/src/data/XYTree.cpp
+++ b/src/data/XYTree.cpp
@@ -106,8 +106,8 @@ XYTree::Tree XYTree::buildXTree(const RankerTable& ranker, const ShortlexResult&
                 }
             }
 
-            // line 18: T_X(T).chld(parent) <- [i, i)
-            parent_node->children = Interval(i, i);
+            // line 18: T_X(T).chld(parent) <- [i, i]   // 논문에서는 [i, i)지만 편의상 [i, i]를 쓰기로
+            parent_node->children = Interval(i, i - 1); // line 19 에서 [i, i]로 바뀔 것
         }
         
         // line 19: extend end point of T_X(`T`).chld(parent) by one
@@ -225,8 +225,8 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
                 }
             }
 
-            // line 18: T_Y(T).chld(parent) <- [i, i)
-            parent_node->children = Interval(i, i);
+            // line 18: T_Y(T).chld(parent) <- [i, i]   // 논문에서는 [i, i)지만 편의상 [i, i]를 쓰기로
+            parent_node->children = Interval(i, i - 1); // line 19 에서 [i, i]로 바뀔 것
         }
 
         // line 19: extend end point of T_Y(T).chld(parent) by one

--- a/src/data/XYTree.cpp
+++ b/src/data/XYTree.cpp
@@ -117,7 +117,8 @@ XYTree::Tree XYTree::buildXTree(const RankerTable& ranker, const ShortlexResult&
             tree.children.back().push_back(i);
         }
 
-        tree.parent[i] = nodes[parent]; // due to the abuse of notation prnt(i)
+        // line 21: T_X(T).prnt(i) <- parent (Note: 논문의 Algorithm 1 에서는 i가 Nodes에 포함인 경우에만 하도록 되어있지만, 6페이지에 모든 i에 대하여 prnt(i)가 작동하도록 하게끔 abuse한다는 내용이 있음)
+        tree.parent[i] = nodes[parent];
         cout << "Set parent of " << i << " to " << parent << endl;
     }
 
@@ -239,6 +240,7 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
             tree.children.back().push_back(i);
         }
 
+        // line 21: T_Y(T).prnt(i) <- parent (Note: 논문의 Algorithm 1 에서는 i가 Nodes에 포함인 경우에만 하도록 되어있지만, 6페이지에 모든 i에 대하여 prnt(i)가 작동하도록 하게끔 abuse한다는 내용이 있음)
         tree.parent[i] = nodes[parent];
         cout << "Set parent of " << i << " to " << parent << endl;
     }

--- a/src/data/XYTree.cpp
+++ b/src/data/XYTree.cpp
@@ -230,7 +230,7 @@ XYTree::Tree XYTree::buildYTree(const RankerTable& ranker, const ShortlexResult&
             }
         }
 
-        // line 18: T_Y(T)chld(parent) <- [i, i)
+        // line 18: T_Y(T).chld(parent) <- [i, i)
         // line 19: extend end point of T_Y(T).chld(parent) by one
         if (parent != -1) {
             tree.children[parent].push_back(i);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,10 +69,10 @@ int main() {
     }
 
     // Build X-tree
-    XYTree::Node xRoot = *XYTree::buildXTree(ranker, pattern_shortlex, randText);
+    XYTree::Tree x_tree = XYTree::buildXTree(ranker, pattern_shortlex, randText);
 
     // Build Y-tree
-    XYTree::Node yRoot = *XYTree::buildYTree(ranker, pattern_shortlex, randText);
+    XYTree::Tree y_tree = XYTree::buildYTree(ranker, pattern_shortlex, randText);
     
     return 0;
 }

--- a/src/xy_tree.cpp
+++ b/src/xy_tree.cpp
@@ -30,11 +30,9 @@ void printTree(const Tree& tree) {
             cout << setw(10) << tree.parent[i]->index;
         }
 
-        for (int child : tree.children[i]) {
-            cout << child << " ";
-        }
+        cout << "[" << current_node->children.start << "," << current_node->children.end << ")";
 
-        cout << "\n";
+        cout << endl;
     }
 
     cout << "----------------------\n";

--- a/src/xy_tree.cpp
+++ b/src/xy_tree.cpp
@@ -30,7 +30,7 @@ void printTree(const Tree& tree) {
             cout << setw(10) << tree.parent[i]->index;
         }
 
-        cout << "[" << current_node->children.start << "," << current_node->children.end << ")";
+        cout << "[" << current_node->children.start << "," << current_node->children.end << "]";
 
         cout << endl;
     }

--- a/src/xy_tree.cpp
+++ b/src/xy_tree.cpp
@@ -1,25 +1,43 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <iomanip>
 
 #include "data/XYTree.h"
 #include "utils/Alphabet.h"
+#include "utils/Common.h"
 
 using namespace std;
 using namespace XYTree;
 
 // -------------------- Print Tree --------------------
-void printTree(const shared_ptr<Node>& node, const string& w, string indent = "", bool isLast = true, int depth = 0) {
-    if (true) {
-        cout << indent;
-        if (depth > 0) cout << (isLast ? "└── " : "├── ");
-        int position = node->index;
-        cout << position << "(r=" << node->r << ", next=" << node->next->index << ")" << "\n";
-        indent += (isLast ? "    " : "│   ");
+void printTree(const Tree& tree) {
+    cout << "Visual Tree Structure:\n";
+    cout << "----------------------\n";
+    cout << left << setw(10) << "Index"
+              << setw(10) << "Parent"
+              << "Children\n";
+
+    ;
+    for (shared_ptr<XYTree::Node> current_node = tree.root->next; current_node != tree.root; current_node = current_node->next) {
+        int i = current_node->index;
+        cout << left << setw(10) << i;
+        
+        if (tree.parent[i]->index == INF) {
+            cout << setw(10) << "INF";
+        }
+        else {
+            cout << setw(10) << tree.parent[i]->index;
+        }
+
+        for (int child : tree.children[i]) {
+            cout << child << " ";
+        }
+
+        cout << "\n";
     }
-    for (size_t i = 0; i < node->children.size(); ++i) {
-        printTree(node->children[i], w, indent, i == node->children.size() - 1, depth+1);
-    }
+
+    cout << "----------------------\n";
 }
 
 // ------------------
@@ -71,11 +89,16 @@ int main(int argc, char* argv[]) {
         k + 1
     );
 
-    shared_ptr<Node> T_X = buildXTree(rankers, pattern_shortlex, t);
-    shared_ptr<Node> T_Y = buildYTree(rankers, pattern_shortlex, t);
+    XYTree::Tree T_X = buildXTree(rankers, pattern_shortlex, t);
+    XYTree::Tree T_Y = buildYTree(rankers, pattern_shortlex, t);
 
-    printTree(T_X, t);
-    printTree(T_Y, t);
+    cout << "X-tree:" << endl;
+    printTree(T_X);
+    
+    cout << endl;
+
+    cout << "Y-tree:" << endl;
+    printTree(T_Y);
 
     return 0;
 }


### PR DESCRIPTION
논문에 있는 T.prnt랑 T.chld 구현

Node 자료구조가 바뀌다보니, xy_tree 테스트 드라이버 출력 형식이 조금 바뀌었습니다:
(아래는 논문에 나온 예시로 테스트한 것)
![image](https://github.com/user-attachments/assets/f61935d7-7da2-436c-ac0f-ed8ccf56daf4)