### PR TITLE
fix: CalculateUniversality

### DIFF
--- a/include/utils/CalculateUniversality.h
+++ b/include/utils/CalculateUniversality.h
@@ -34,7 +34,6 @@ inline int calculateUniversalityIndex(const std::string& text) {
             ++archCount;
   
             // move left to end of arch (minimize window)
-            ++right;  // move past the arch
             left = right;
   
             // reset counts


### PR DESCRIPTION
calculateUniversality가 arch가 끝난 후 이후 char 1개를 무시하던 현상 수정